### PR TITLE
Config cleanup

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,16 +1,126 @@
-This folder contains the apis that the frontend hits for info. These will all have some kind of parser that parses the raw API data, then 
-returns the parsed API data for the frontend to later use. 
+# API Structure
 
-The types and apis that are avaliable to the frontend are summarized in the `./spec` folder. 
 
-The general structure followed here is 
+This folder contains the apis that the frontend hits for info. The basic job of an API is to gather data from
+an external source and return a parsed version for the frontend to later use. 
 
-`api.go` will have the external API function that is the only entrypoint into this API. 
+The types and apis that are avaliable to the frontend are summarized in the `./spec` folder. (still WIP)
 
-`implementations.go` will hold the implementations for the `InternalAPI` methods. 
+Below are some files showing the barebones structure of an api called `NAME`
 
-`types.go` will hold the external API type that we parse from our GET request. 
+**api/NAME/api.go** contains most of the core logic
+```go
+package NAME
 
-`utils.go` will hold the util functions. 
+import (
+    "github.com/pisign/pisign-backend/types"
+    // import other necessary packages
+)
 
-If you think something can be made generic, consider putting it in the higher level `utils/` package. 
+// API struct to hold proper data types
+type API struct {
+	types.BaseAPI
+	Config types.NAMEConfig
+    ResponseObject Response
+
+    // Any other necessary fields
+}
+
+// NewAPI creates a new API
+func NewAPI(configChan chan types.ConfigMessage, pool types.Pool) *API {
+	a := new(API)
+	a.BaseAPI.Init("<NAME>", configChan, pool)
+	if a.Pool != nil {
+		a.Pool.Register(a)
+	}
+	
+    // Default config values, eg:
+    // a.Location = "Local"
+	return a
+}
+
+// Configure from json message sent from client
+func (a *API) Configure(body types.ConfigMessage) {
+    // Also call parent Configure first
+	a.ConfigurePosition(body.Position)
+
+    // Catch error if object can not be configured properly
+	if err := json.Unmarshal(body.Config, &a.Config); err != nil {
+		log.Println("Could not properly configure clock")
+		a.Config = oldConfig
+		return
+	}
+    // Add other checks or logic as necessary	
+    
+    // Update the connected pool object
+	a.Pool.Save()
+}
+
+// Data performs the bulk work of retrieving the data from an external source
+func (a *API) Data() interface{} {
+    // Main logic here
+
+	return Response{/*Fill in proper fields*/}
+}
+
+// Run main entry point to API
+func (a *API) Run(w types.Socket) {
+    log.Println("Running <NAME>")
+    
+    // Creates a timer that goes off every second
+    ticker := time.NewTicker(1 * time.Second)
+
+	defer func() {
+		log.Println("STOPPING <NAME>")
+        ticker.Stop()
+        // Any additional cleanup work goes here
+	}()
+	for {
+		select {
+		case body := <-a.ConfigChan: // Configuration message received
+			a.Configure(body)
+		case <-w.Close(): // Socket connection was closed, stop running
+			return
+		case <- ticker.C:
+			// Do any necessary pre-processing logic
+			w.Send(a.Data()) // Send data to client through websocket
+		}
+	}
+}
+```
+
+**api/NAME/types.go** holds all internal types not needed by the client
+```go
+package NAME
+
+// Internal type definitions go here
+// All types should all be unexported (lowercase)
+```
+
+**api/NAME/utils.go** holds utility functions particular to that API.
+If you think a function can be made generic, consider putting it in the higher level `utils/` package.
+
+```go
+package NAME
+
+// Utility functions go here
+// All functions should be unexported (lowercase)
+```
+
+**types/NAME.go** holds all the public interfaces that need to be accesible both by the api and the client
+```go
+package types
+
+// All types should be exported (capital first letter)
+
+// NAMEResponse holds all of the data being sent to the client
+type NAMEResponse struct {
+	// Add any necessary fields
+}
+
+// NAMEConfig holds all necessary configuration parameters being sent from the client
+type NAMEConfig struct {
+	// Add any necessary fields
+}
+
+```

--- a/api/clock/types.go
+++ b/api/clock/types.go
@@ -1,8 +1,3 @@
 package clock
 
-import (
-	"time"
-)
-
-// TimeData data to hold time
-type TimeData time.Time
+// No internal types at the moment

--- a/api/weather/api.go
+++ b/api/weather/api.go
@@ -11,7 +11,7 @@ import (
 // API for weather
 type API struct {
 	types.BaseAPI
-	config     types.WeatherConfig
+	Config     types.WeatherConfig
 	LastCalled time.Time `json:"-"`
 	// This is the object we get from the backend API - we could possible remove this and just have the ResponseObject
 	DataObject OpenWeatherResponse `json:"-"`
@@ -29,7 +29,7 @@ func (a *API) Data() interface{} {
 	}
 
 	// Otherwise, update the response object
-	a.DataObject.Update(a.config)
+	a.DataObject.Update(a.Config)
 	response := a.DataObject.Transform()
 	a.ResponseObject = *(response.(*types.WeatherResponse))
 	a.LastCalled = time.Now()
@@ -51,7 +51,7 @@ func (a *API) Configure(body types.ConfigMessage) {
 	a.ConfigurePosition(body.Position)
 	log.Println("Configuring WEATHER:", body)
 
-	if err := json.Unmarshal(body.Config, &a.config); err != nil {
+	if err := json.Unmarshal(body.Config, &a.Config); err != nil {
 		log.Println("Could not properly configure weather")
 		return
 	}

--- a/api/weather/types.go
+++ b/api/weather/types.go
@@ -72,7 +72,7 @@ type OpenWeatherResponse struct {
 
 // Update builds the data object
 func (o *OpenWeatherResponse) Update(arguments interface{}) {
-	a := (arguments).(APISettings)
+	a := (arguments).(types.WeatherConfig)
 	apikey := a.APIKey
 	zipcode := a.Zip
 

--- a/exampleClients/widgets.html
+++ b/exampleClients/widgets.html
@@ -37,7 +37,7 @@ window.addEventListener("load", function(evt) {
         var widgetInputDiv = document.createElement("div")
         var widgetInputText = document.createElement("input")
         widgetInputText.type = "text"
-        widgetInputText.value = `{"Position":{"x": 5, "y": 10}, "API":{"Location":"America/Chicago"}}`
+        widgetInputText.value = `{"config":{"Location":"America/Chicago"}}`
 
         widgetInputSend = document.createElement("button")
         widgetInputSend.innerHTML = "Send Message"

--- a/types/clock.go
+++ b/types/clock.go
@@ -1,7 +1,7 @@
 package types
 
-// ClockOut main format for data coming out of clock api
-type ClockOut struct {
+// ClockResponse main format for data coming out of clock api
+type ClockResponse struct {
 	Time string
 }
 

--- a/types/config.go
+++ b/types/config.go
@@ -1,5 +1,7 @@
 package types
 
+import "encoding/json"
+
 // Position information for api widgets
 type Position struct {
 	X int    `json:"x"`
@@ -7,4 +9,10 @@ type Position struct {
 	W int    `json:"w"`
 	H int    `json:"h"`
 	I string `json:"i"`
+}
+
+// ConfigMessage for configuring
+type ConfigMessage struct {
+	Position
+	Config json.RawMessage
 }

--- a/types/config.go
+++ b/types/config.go
@@ -1,10 +1,10 @@
 package types
 
-// Position struct
+// Position information for api widgets
 type Position struct {
-	X int `json:"x"`
-	Y int  `json:"y"`
-	W int `json:"w"`
-	H int `json:"h"`
-	I string `json:"i"`
+	x int
+	y int
+	w int
+	h int
+	i string
 }

--- a/types/config.go
+++ b/types/config.go
@@ -2,9 +2,9 @@ package types
 
 // Position information for api widgets
 type Position struct {
-	x int
-	y int
-	w int
-	h int
-	i string
+	X int    `json:"x"`
+	Y int    `json:"y"`
+	W int    `json:"w"`
+	H int    `json:"h"`
+	I string `json:"i"`
 }

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -1,9 +1,5 @@
 package types
 
-import (
-	"encoding/json"
-)
-
 // DataObject holds the data from the external API
 type DataObject interface {
 	// Build builds the data object
@@ -28,7 +24,6 @@ type API interface {
 }
 
 // Socket interface, needed to avoid circular dependency with Socket package
-// TODO: See if we can remove this interface without adding a circular dependency?
 type Socket interface {
 	// Read information from the client
 	Read()
@@ -46,10 +41,4 @@ type Pool interface {
 	Register(API)
 	Unregister(API)
 	Save()
-}
-
-// ConfigMessage for configuring
-type ConfigMessage struct {
-	Position
-	Config json.RawMessage
 }

--- a/types/weather.go
+++ b/types/weather.go
@@ -74,3 +74,9 @@ type WeatherResponse struct {
 func (w WeatherResponse) Cache() {
 	// TODO figure out how to cache these results for later, use something like redis?
 }
+
+// WeatherConfig are the config settings for the API
+type WeatherConfig struct {
+	Zip    int
+	APIKey string
+}


### PR DESCRIPTION
- Moved around and renamed some of the API types
- Standardized config as `api.Config` for all APIs (with differing types)
- Cleaned up `Configure` functions for `clock` and `weather` to make them easier to read and more error-proof
- Added example code for how to create a new API type in the `api/README.md` file