### PR TITLE
Restructured message sending to client

### DIFF
--- a/socket/socket.go
+++ b/socket/socket.go
@@ -31,14 +31,6 @@ func Create(configChan chan types.ClientMessage, conn *websocket.Conn) *Socket {
 	return socket
 }
 
-// SendErrorMessage sends the error message
-func (w *Socket) SendErrorMessage(message string) {
-	w.Send(types.BaseMessage{
-		Status:       types.StatusFailure,
-		ErrorMessage: message,
-	})
-}
-
 func (w *Socket) Read() {
 	// The only time the socket is recieving data is when it is getting configutation data
 	defer func() {
@@ -68,6 +60,31 @@ func (w *Socket) Read() {
 		default:
 			log.Printf("Unknown client action: %s\n", message.Action)
 		}
+	}
+}
+
+// SendSuccess sends a success message
+func (w *Socket) SendSuccess(msg interface{}) {
+	w.Send(types.BaseMessage{
+		Status: types.StatusSuccess,
+		Data:   msg,
+	})
+}
+
+// SendErrorMessage sends the error message
+func (w *Socket) SendErrorMessage(err error) {
+	w.Send(types.BaseMessage{
+		Status: types.StatusFailure,
+		Error:  err.Error(),
+	})
+}
+
+// SendDataOrError sends the appropriate data or error
+func (w *Socket) SendDataOrError(data interface{}, err error) {
+	if err != nil {
+		w.SendErrorMessage(err)
+	} else {
+		w.SendSuccess(data)
 	}
 }
 

--- a/socket/socket.go
+++ b/socket/socket.go
@@ -79,15 +79,6 @@ func (w *Socket) SendErrorMessage(err error) {
 	})
 }
 
-// SendDataOrError sends the appropriate data or error
-func (w *Socket) SendDataOrError(data interface{}, err error) {
-	if err != nil {
-		w.SendErrorMessage(err)
-	} else {
-		w.SendSuccess(data)
-	}
-}
-
 // Send out to client through websocket
 func (w *Socket) Send(msg interface{}) {
 	w.Conn.WriteJSON(msg)

--- a/types/api.go
+++ b/types/api.go
@@ -54,8 +54,18 @@ func (b *BaseAPI) SetPosition(pos Position) {
 	b.Position = pos
 }
 
+// Stop the api
 func (b *BaseAPI) Stop() {
 	log.Printf("Stopping api %s (%s)\n", b.Name, b.UUID)
 	b.StopChan <- true
 	log.Printf("Done stopping!\n")
+}
+
+// Send to websocket
+func (b *BaseAPI) Send(data interface{}, err error) {
+	if err != nil {
+		b.Socket.SendErrorMessage(err)
+	} else {
+		b.Socket.SendSuccess(data)
+	}
 }

--- a/types/api.go
+++ b/types/api.go
@@ -30,18 +30,22 @@ func (b *BaseAPI) GetName() string {
 	return b.Name
 }
 
+// GetUUID returns the uuid
 func (b *BaseAPI) GetUUID() uuid.UUID {
 	return b.UUID
 }
 
+// GetSocket returns the apis socket connection
 func (b *BaseAPI) GetSocket() Socket {
 	return b.Socket
 }
 
+// GetPosition returns position
 func (b *BaseAPI) GetPosition() Position {
 	return b.Position
 }
 
+// Configure based on an incoming client message
 func (b *BaseAPI) Configure(message ClientMessage) {
 	switch message.Action {
 	case ConfigurePosition, Initialize:
@@ -49,7 +53,7 @@ func (b *BaseAPI) Configure(message ClientMessage) {
 	}
 }
 
-// ConfigurePosition configures position
+// SetPosition configures position
 func (b *BaseAPI) SetPosition(pos Position) {
 	b.Position = pos
 }

--- a/types/clock.go
+++ b/types/clock.go
@@ -2,7 +2,6 @@ package types
 
 // ClockResponse main format for data coming out of clock api
 type ClockResponse struct {
-	BaseMessage
 	Time string
 }
 

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -48,9 +48,9 @@ type Socket interface {
 	// SendErrorMessage sends error message
 	SendErrorMessage(error)
 	SendSuccess(interface{})
-	SendDataOrError(interface{}, error)
 }
 
+// Unregister stores info about which api to unregister, and weather the pool should be saved
 type Unregister struct {
 	API  API
 	Save bool

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -20,7 +20,7 @@ type API interface {
 	Run()
 
 	// Data gets the data to send
-	Data() interface{}
+	Data() (interface{}, error)
 
 	GetName() string
 	GetUUID() uuid.UUID
@@ -28,6 +28,7 @@ type API interface {
 	GetPosition() Position
 	SetPosition(Position)
 	Stop()
+	Send(interface{}, error)
 }
 
 // Socket interface, needed to avoid circular dependency with Socket package
@@ -45,7 +46,9 @@ type Socket interface {
 	Config() chan ClientMessage
 
 	// SendErrorMessage sends error message
-	SendErrorMessage(string)
+	SendErrorMessage(error)
+	SendSuccess(interface{})
+	SendDataOrError(interface{}, error)
 }
 
 type Unregister struct {

--- a/types/message.go
+++ b/types/message.go
@@ -1,7 +1,9 @@
 package types
 
+// MessageStatus indicates the broad type of message sent back to the client
 type MessageStatus string
 
+// Enumerates different possible message statuses
 const (
 	StatusSuccess MessageStatus = "success"
 	StatusFailure MessageStatus = "failure"

--- a/types/message.go
+++ b/types/message.go
@@ -10,6 +10,7 @@ const (
 // BaseMessage is the base message we are sending to frontend
 // All structs being send to the frontend should inherit from this
 type BaseMessage struct {
-	Status       MessageStatus
-	ErrorMessage string
+	Status MessageStatus
+	Error  string      `json:",omitempty"`
+	Data   interface{} `json:",omitempty"`
 }


### PR DESCRIPTION
- The `BaseMessage` type now contains either a `Data` or `Error` field, depending on the status type.
- The socket now has a `SendDataOrError` which takes both a data interface and an error, and sends the appropriate message depending on whether or not the error is `nil`
- Now each API `Data` function returns an `(interface{}, error)` tuple, and no longer has to create a new `BaseMessage` object