### PR TITLE
UUID deduplication

### DIFF
--- a/api/factory.go
+++ b/api/factory.go
@@ -17,12 +17,12 @@ type InvalidAPIError struct {
 }
 
 // NewAPI returns a new instance of a specific API based on the name
-func NewAPI(name string, socket types.Socket, pool types.Pool, id uuid.UUID) (types.API, error) {
+func NewAPI(name string, sockets map[types.Socket]bool, pool types.Pool, id uuid.UUID) (types.API, error) {
 	switch name {
 	case "weather":
-		return weather.NewAPI(socket, pool, id), nil
+		return weather.NewAPI(sockets, pool, id), nil
 	case "clock":
-		return clock.NewAPI(socket, pool, id), nil
+		return clock.NewAPI(sockets, pool, id), nil
 	default:
 		return nil, InvalidAPIError{name}
 	}

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -1,7 +1,9 @@
 package pool
 
 import (
+	"errors"
 	"log"
+	"net"
 
 	"github.com/google/uuid"
 	"github.com/pisign/pisign-backend/api"
@@ -13,7 +15,7 @@ import (
 type Pool struct {
 	registerChan   chan types.API
 	unregisterChan chan types.Unregister
-	Map            map[types.API]bool
+	Map            map[uuid.UUID]types.API
 	name           string
 }
 
@@ -22,7 +24,7 @@ func NewPool() *Pool {
 	return &Pool{
 		registerChan:   make(chan types.API),
 		unregisterChan: make(chan types.Unregister),
-		Map:            make(map[types.API]bool),
+		Map:            make(map[uuid.UUID]types.API),
 		name:           "main",
 	}
 }
@@ -31,8 +33,8 @@ func NewPool() *Pool {
 func (pool *Pool) List() []types.API {
 	keys := make([]types.API, len(pool.Map))
 	i := 0
-	for k := range pool.Map {
-		keys[i] = k
+	for _, a := range pool.Map {
+		keys[i] = a
 		i++
 	}
 	return keys
@@ -48,36 +50,24 @@ func (pool *Pool) Save() {
 	}
 }
 
-// Start main entry point of a pool
-func (pool *Pool) Start() {
-	for {
-		select {
-		case a := <-pool.registerChan:
-			pool.Map[a] = true
-			log.Printf("New API: %s\n", a.GetName())
-			log.Println("Size of Connection Pool: ", len(pool.Map))
-			pool.Save()
-		case data := <-pool.unregisterChan:
-			delete(pool.Map, data.API)
-			if data.Save {
-				log.Printf("Saving API: %s\n", data.API.GetName())
-				pool.Save()
-			}
-			log.Printf("Deleted API: %s\n", data.API.GetName())
-			log.Println("Size of Connection Pool: ", len(pool.Map))
-		}
-	}
-}
-
 // Add a new API to the pool
 func (pool *Pool) Add(apiName string, id uuid.UUID, sockets map[types.Socket]bool) (types.API, error) {
-	log.Printf("Adding new api: %s\n", id)
 	if a := pool.containsUUID(id); a != nil {
+		for existingSocket := range a.GetSockets() {
+			log.Printf("Remote addr: %+v\n", existingSocket.RemoteAddr())
+			for newSocket := range sockets {
+				if equal, ip := equalAddresses(existingSocket.RemoteAddr(), newSocket.RemoteAddr()); equal {
+					log.Printf("API (%v) already exists on client %v, cannot recreate!\n", id, ip)
+					return nil, errors.New("API already exists on client")
+				}
+			}
+		}
 		// Add new socket to existing api
 		log.Printf("API (%s) Already exists!\n", id)
 		for socket := range sockets {
 			a.AddSocket(socket)
 		}
+		// TODO Force data send to new socket
 
 		return a, nil
 	}
@@ -97,34 +87,55 @@ func (pool *Pool) Add(apiName string, id uuid.UUID, sockets map[types.Socket]boo
 
 // Register a new API
 func (pool *Pool) Register(a types.API) {
-	pool.registerChan <- a
+	pool.Map[a.GetUUID()] = a
+	log.Printf("New API: %s\n", a.GetName())
+	log.Println("Size of Connection Pool: ", len(pool.Map))
+	pool.Save()
 }
 
 // Unregister a new API
 func (pool *Pool) Unregister(data types.Unregister) {
-	pool.unregisterChan <- data
+	delete(pool.Map, data.API.GetUUID())
+	if data.Save {
+		log.Printf("Saving API: %s\n", data.API.GetName())
+		pool.Save()
+	}
+	log.Printf("Deleted API: %s\n", data.API.GetName())
+	log.Println("Size of Connection Pool: ", len(pool.Map))
 }
 
 // Switch from one API type to another, while maintaining the same socket
 func (pool *Pool) Switch(a types.API, name string) error {
+	log.Printf("Switching API: %s -> %s\n", a.GetName(), name)
 	sockets := a.GetSockets()
 	id := a.GetUUID()
 	pos := a.GetPosition()
 	a.Stop()
 	pool.Unregister(types.Unregister{API: a, Save: true})
-	a, err := pool.Add(name, id, sockets)
+	newAPI, err := pool.Add(name, id, sockets)
 	if err != nil {
 		return err
 	}
-	a.SetPosition(pos)
+	newAPI.SetPosition(pos)
 	return nil
 }
 
 func (pool *Pool) containsUUID(targetUUID uuid.UUID) types.API {
-	for a := range pool.Map {
-		if a.GetUUID() == targetUUID {
+	for id, a := range pool.Map {
+		if id == targetUUID {
 			return a
 		}
 	}
 	return nil
+}
+
+func equalAddresses(a net.Addr, b net.Addr) (bool, net.IP) {
+	// TODO figure out if we'll ever encounter non-tcp addresses?
+	tcpA := a.(*net.TCPAddr)
+	tcpB := b.(*net.TCPAddr)
+	if tcpA.IP.Equal(tcpB.IP) {
+		return true, tcpA.IP
+	}
+
+	return false, nil
 }

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -67,7 +67,8 @@ func (pool *Pool) Add(apiName string, id uuid.UUID, sockets map[types.Socket]boo
 		for socket := range sockets {
 			a.AddSocket(socket)
 		}
-		// TODO Force data send to new socket
+		// TODO is this the proper way to force a data update? It seems a bit off for some reason, but it works
+		a.Send(a.Data())
 
 		return a, nil
 	}

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -121,10 +121,8 @@ func (pool *Pool) Switch(a types.API, name string) error {
 }
 
 func (pool *Pool) containsUUID(targetUUID uuid.UUID) types.API {
-	for id, a := range pool.Map {
-		if id == targetUUID {
-			return a
-		}
+	if a, ok := pool.Map[targetUUID]; ok {
+		return a
 	}
 	return nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -33,8 +33,10 @@ func socketConnectionHandler(pool types.Pool, w http.ResponseWriter, r *http.Req
 	id := uuid.MustParse(idString)
 
 	ws := socket.Create(configChan, conn)
+	sockets := make(map[types.Socket]bool)
+	sockets[ws] = true
 
-	_, err = pool.Add(apiName, id, ws)
+	_, err = pool.Add(apiName, id, sockets)
 	if err != nil {
 		conn.WriteMessage(websocket.TextMessage, []byte(err.Error()))
 		conn.Close()

--- a/server/server.go
+++ b/server/server.go
@@ -73,7 +73,6 @@ func serveLayouts(w http.ResponseWriter, r *http.Request) {
 
 func setupRoutes() {
 	p := pool.NewPool()
-	go p.Start()
 	http.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
 		socketConnectionHandler(p, w, r)
 	})

--- a/types/api.go
+++ b/types/api.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"errors"
+	"fmt"
 	"log"
 
 	"github.com/google/uuid"
@@ -68,6 +70,10 @@ func (b *BaseAPI) Configure(message ClientMessage) error {
 		return b.Pool.Switch(b, message.Name)
 	case Delete:
 		b.CloseChan <- CloseType{Sockets: b.Sockets, Save: true}
+	case ConfigureAPI:
+		break
+	default:
+		return errors.New(fmt.Sprintf("Invalid Client Message action: %s!", message.Action))
 	}
 	return nil
 }

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -24,11 +24,13 @@ type API interface {
 
 	GetName() string
 	GetUUID() uuid.UUID
-	GetSocket() Socket
+	GetSockets() map[Socket]bool
 	GetPosition() Position
 	SetPosition(Position)
 	Stop()
 	Send(interface{}, error)
+
+	AddSocket(Socket)
 }
 
 // Socket interface, needed to avoid circular dependency with Socket package
@@ -63,5 +65,5 @@ type Pool interface {
 	Unregister(Unregister)
 	Switch(API, string) error
 	Save()
-	Add(apiName string, id uuid.UUID, ws Socket) (API, error)
+	Add(string, uuid.UUID, map[Socket]bool) (API, error)
 }

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -1,6 +1,10 @@
 package types
 
-import "github.com/google/uuid"
+import (
+	"net"
+
+	"github.com/google/uuid"
+)
 
 // DataObject holds the data from the external API
 type DataObject interface {
@@ -28,6 +32,7 @@ type API interface {
 	GetPosition() Position
 	SetPosition(Position)
 	Stop()
+	Running() bool
 	Send(interface{}, error)
 
 	AddSocket(Socket)
@@ -41,15 +46,16 @@ type Socket interface {
 	// Send information to the client
 	Send(interface{})
 
-	// Close the socket
-	Close() chan bool
-
-	// Configuration data
-	Config() chan ClientMessage
+	CloseChan() chan bool
+	ConfigChan() chan ClientMessage
 
 	// SendErrorMessage sends error message
 	SendErrorMessage(error)
 	SendSuccess(interface{})
+
+	// Wrappers around underlying websocket connection
+	Close() error
+	RemoteAddr() net.Addr
 }
 
 // Unregister stores info about which api to unregister, and weather the pool should be saved
@@ -60,7 +66,6 @@ type Unregister struct {
 
 // Pool pool
 type Pool interface {
-	Start()
 	Register(API)
 	Unregister(Unregister)
 	Switch(API, string) error


### PR DESCRIPTION
A few structural changes, along with a few features
- APIs are now stored in the map by their UUID
  - If a UUID already exists on the *same* client as a new incoming socket, it is rejected
  - If a UUID already exists in the pool, but there is no socket connection to the requesting client, a new socket connection is added to the existing api. This should make remote viewing and editing super simply
  - If the UUID does not exist, a new api instance is spun up and added to the pool
- Sending an API message now broadcasts the message to all sockets connected to that api (there is no longer a strict one-to-one relationship between api and socket)
- Moved as much logic as possible to the `BaseAPI` class type
  - Implemented all `types.API` interface functions.
  - Many functions inside of child APIs (eg `clock.Configure`) must now call the Base version (eg `clock.BaseAPI.Configure`)

Two known `TODOs` that I want to address and see if they are an issue
- In `pool.Add`, I am forcing a data update whenever a new socket connection is created to a NEW client, by calling `a.Send(a.Data())`. This seems weird to me, but it works, so I want your thoughts on if there is a cleaner way to accomplish the task
- In `pool.equalAddresses()` I always convert the `net.Addr` objects into `net.TCPAddr` objects. Is there any case where we won't be dealing with TCPAddrs? If so, what do you think would be the best way to handle these cases?