### PR TITLE
Trying to fix infinite cpu usage bug

### DIFF
--- a/api/clock/api.go
+++ b/api/clock/api.go
@@ -85,7 +85,8 @@ func (a *API) Run() {
 		ticker.Stop()
 		log.Printf("STOPPING CLOCK: %s\n", a.UUID)
 	}()
-	for a.Running() {
+	stop := a.AddStopChan()
+	for {
 		select {
 		case body := <-a.ConfigChan:
 			if err := a.Configure(body); err != nil {
@@ -106,8 +107,8 @@ func (a *API) Run() {
 		case t := <-ticker.C:
 			a.time = t
 			a.Send(a.Data())
-		default:
-			continue
+		case <-stop:
+			return
 		}
 	}
 }

--- a/api/weather/api.go
+++ b/api/weather/api.go
@@ -89,11 +89,12 @@ func (a *API) Run() {
 	go a.BaseAPI.Run()
 	a.Send(a.Data())
 	ticker := time.NewTicker(10 * time.Second)
+	stop := a.AddStopChan()
 	defer func() {
 		ticker.Stop()
 		log.Printf("STOPPING WEATHER: %s\n", a.UUID)
 	}()
-	for a.Running() {
+	for {
 		select {
 		case body := <-a.ConfigChan:
 			err := a.Configure(body)
@@ -102,8 +103,8 @@ func (a *API) Run() {
 			}
 		case <-ticker.C:
 			a.Send(a.Data())
-		default:
-			continue
+		case <-stop:
+			return
 		}
 	}
 }

--- a/types/interfaces.go
+++ b/types/interfaces.go
@@ -32,8 +32,8 @@ type API interface {
 	GetPosition() Position
 	SetPosition(Position)
 	Stop()
-	Running() bool
 	Send(interface{}, error)
+	Running() bool
 
 	AddSocket(Socket)
 }


### PR DESCRIPTION
Fixes #41. No more wasted cpu cycles. When a new concurrent function is launched, it can create a new special channel by calling `BaseApi.AddStopChan()` to be notified when the API is shutdown. When `BaseAPI.Stop()` is called, it sends a message to all those channels