### PR TITLE
/layouts doesnt work with just serving static files

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -81,9 +81,9 @@ func setupRoutes() {
 	http.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
 		socketConnectionHandler(p, w, r)
 	})
-	//http.HandleFunc("/layouts", serveLayouts)
+	http.HandleFunc("/layouts", serveLayouts)
 	setupStaticFiles("assets/images", "/images/")
-	setupStaticFiles("assets/layouts", "/layouts/")
+	//setupStaticFiles("assets/layouts", "/layouts/")
 	setupStaticFiles("dist", "/")
 }
 


### PR DESCRIPTION
Need to manually set CORS headers or else we cannot serve the layouts.json files. This reverts the change on master that reintroduced CORS error. 