### PR TITLE
need at least something in the config slot due to frontend parsing 

### DIFF
--- a/api/sysinfo/api.go
+++ b/api/sysinfo/api.go
@@ -12,7 +12,7 @@ import (
 
 type API struct {
 	types.BaseAPI
-	Config         interface{} // TODO do we need a config?
+	Config         *types.SysInfoConfig
 	ResponseObject types.SysInfoResponse
 	LastCalled     time.Time `json:"-"`
 	ValidCache     bool
@@ -31,6 +31,7 @@ func NewAPI(sockets map[types.Socket]bool, pool types.Pool, id uuid.UUID) *API {
 func (a *API) Configure(message types.ClientMessage) error {
 	// TODO this requires no configuration
 	// Make sure the client widget is immediately sent new data with new config options
+	a.Config = &types.SysInfoConfig{}
 	defer func() {
 		if a.Pool != nil && a.Sockets != nil {
 			a.Pool.Save()

--- a/spec/specfile
+++ b/spec/specfile
@@ -53,6 +53,7 @@ type Sys {
 }
 
 type BaseMessage {
+    Position     Position
     Status       MessageStatus
     Error        string
     Data         interface {}

--- a/types/sysinfo.go
+++ b/types/sysinfo.go
@@ -5,3 +5,6 @@ type SysInfoResponse struct {
 	Total       uint64
 	UsedPercent float64
 }
+
+type SysInfoConfig struct {
+}


### PR DESCRIPTION
Sysinfo needs at least a config, even if empty, for frontend to parse. 